### PR TITLE
Add slash to end of status update URI to work around flaky server code

### DIFF
--- a/SpaceMonitor.py
+++ b/SpaceMonitor.py
@@ -45,7 +45,7 @@ class SpaceAPIOpenClose: # publish open/closed status via the SpaceAPI
 		f = open("/home/pi/spaceapi-token", "r") #"/home/pi/spaceapi-net.pem"
 		try:
 			s = self.json.dumps({"state" : {"open" : status}}, separators=(',', ':'))
-			r = self.requests.get(self.base_uri + "/sensor/set", verify=False,
+			r = self.requests.get(self.base_uri + "/sensor/set/", verify=False,
 			                      params={"sensors": s, "key": f.readline().strip()})
 			if self.logging.getLogger().isEnabledFor(self.logging.DEBUG):
 				text = r.text


### PR DESCRIPTION
This appears to fix the issue where SpaceAPI status updates would appear to succeed (HTTP 200 response), but nothing would change in the JSON returned by subsequent status requests.  The PHP code that's running on their server seems a bit touchy on exactly how the URI is formatted and is very light on error handling to make it clear when something has gone wrong.
